### PR TITLE
Correction in "developers spelling" in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To get started please read the [GSoC FAQ](https://developers.google.com/open-sou
 All participants will need a Google account in order to join the program. So, save time and create one now. 
 
 ## Contents
-- [Instructions for contributors (students or developpers)](contributor-guidance.md)
+- [Instructions for contributors (students or developers)](contributor-guidance.md)
 - [Instructions for mentors](mentor-guidance.md)
 - [List of ideas for projects](ideas.md)
 

--- a/contributor-guidance.md
+++ b/contributor-guidance.md
@@ -1,5 +1,5 @@
 # Instructions for contributors
-Students and developper wishing to participate in Summer of Code must realise this is a important professional opportunity.
+Students and developers wishing to participate in Summer of Code must realise this is a important professional opportunity.
 You will be required to produce code for IHR during the coding period. Your mentors, IHR researchers, will dedicate a 
 portion of their time to mentoring you. Therefore, we seek candidates who are committed to helping IHR long-term and are 
 willing to both do quality work, and be proactive in communicating with your mentor(s).


### PR DESCRIPTION
Corrected the spelling of 'developers' in the README file of the repository, which was 'developpers' before.